### PR TITLE
Fix failing tests & composer requirement versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-php: 7.1
+php: 7.2
 before_install:
   - composer self-update
   - composer config repositories.packagist.com composer https://repo.packagist.com/snowio/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
 cache:
   directories: $HOME/.composer/cache
 before_script: composer install --no-interaction --dev
-script: phpunit --coverage-clover=coverage.xml
+script: vendor/bin/phpunit --coverage-clover=coverage.xml
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "snowio/akeneo3-fredhopper-integration",
     "require": {
         "php": ">=7.1",
-        "snowio/akeneo3-data-model": "^0.2",
+        "snowio/akeneo3-data-model": "^v0.2",
         "snowio/fredhopper-data-model": "^v0.2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "snowio/akeneo3-fredhopper-integration",
     "require": {
         "php": ">=7.1",
-        "snowio/akeneo3-data-model": "dev-master",
-        "snowio/fredhopper-data-model": "dev-master"
+        "snowio/akeneo3-data-model": "^0.2",
+        "snowio/fredhopper-data-model": "^v0.2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4"

--- a/test/unit/LocalizableAttributeMapperTest.php
+++ b/test/unit/LocalizableAttributeMapperTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace SnowIO\Akeneo3Fredhopper\Test;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use SnowIO\Akeneo3DataModel\AttributeData as AkeneoAttributeData;
 use SnowIO\Akeneo3DataModel\AttributeType as AkeneoAttributeType;
@@ -15,10 +16,10 @@ use SnowIO\Akeneo3DataModel\InternationalizedString as AkeneoInternationalizedSt
 class LocalizableAttributeMapperTest extends TestCase
 {
     /**
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreationOfMapper()
     {
+        self::expectException(InvalidArgumentException::class);
         LocalizableAttributeMapper::of([]);
     }
 

--- a/test/unit/ProductModelProductMapperTest.php
+++ b/test/unit/ProductModelProductMapperTest.php
@@ -62,6 +62,7 @@ class ProductModelProductMapperTest extends TestCase
             'attribute_values' => [
                 'color' => 'blue'
             ],
+            'localizations' => [],
         ]));
         $expected = ProductDataSet::of([FredhopperProductData::of('demontweeks_1001425')
             ->withAttributeValue(FredhopperAttributeValue::of('foo', 'bar'))]);
@@ -111,6 +112,7 @@ class ProductModelProductMapperTest extends TestCase
             'attribute_values' => [
                 'color' => 'blue'
             ],
+            'localizations' => [],
         ]));
         $expected = ProductDataSet::of([FredhopperProductData::of('1001425')
             ->withAttributeValue(FredhopperAttributeValue::of('color', 'blue'))]);


### PR DESCRIPTION
### Description

Currently cannot install both this package and https://github.com/snowio/akeneo3-magento2-integration in the same projects due to conflicting version requirements on `snowio/akeneo3-data-model`:

- https://github.com/snowio/akeneo3-magento2-integration/blob/master/composer.json#L6

```
  Problem 1
    - Conclusion: remove snowio/akeneo3-magento2-integration dev-master
    - Installation request for snowio/akeneo3-magento2-integration dev-master -> satisfiable by snowio/akeneo3-magento2-integration[dev-master].
```

Also, fix failing tests!