### PR TITLE
Fix Tests: localisations in test data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
 cache:
   directories: $HOME/.composer/cache
 before_script: composer install --no-interaction --dev
-script: phpunit --coverage-clover=coverage.xml
+script: vendor/bin/phpunit --coverage-clover=coverage.xml
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/test/unit/LocalizableAttributeMapperTest.php
+++ b/test/unit/LocalizableAttributeMapperTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace SnowIO\Akeneo3Fredhopper\Test;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use SnowIO\Akeneo3DataModel\AttributeData as AkeneoAttributeData;
 use SnowIO\Akeneo3DataModel\AttributeType as AkeneoAttributeType;
@@ -15,10 +16,10 @@ use SnowIO\Akeneo3DataModel\InternationalizedString as AkeneoInternationalizedSt
 class LocalizableAttributeMapperTest extends TestCase
 {
     /**
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreationOfMapper()
     {
+        self::expectException(InvalidArgumentException::class);
         LocalizableAttributeMapper::of([]);
     }
 

--- a/test/unit/ProductModelProductMapperTest.php
+++ b/test/unit/ProductModelProductMapperTest.php
@@ -62,6 +62,7 @@ class ProductModelProductMapperTest extends TestCase
             'attribute_values' => [
                 'color' => 'blue'
             ],
+            'localizations' => [],
         ]));
         $expected = ProductDataSet::of([FredhopperProductData::of('demontweeks_1001425')
             ->withAttributeValue(FredhopperAttributeValue::of('foo', 'bar'))]);
@@ -111,6 +112,7 @@ class ProductModelProductMapperTest extends TestCase
             'attribute_values' => [
                 'color' => 'blue'
             ],
+            'localizations' => [],
         ]));
         $expected = ProductDataSet::of([FredhopperProductData::of('1001425')
             ->withAttributeValue(FredhopperAttributeValue::of('color', 'blue'))]);


### PR DESCRIPTION
## Overview

Looks like the test cases need to account for localizations being modeled by the akeneo 3 data model. This fix will add the localization into the array serializations